### PR TITLE
fix: toSorted to use `arr: readonly T[]` - issue #542

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { iso } from '@iso';
+import React, { useMemo } from "react";
+import { iso } from "@iso";
 
 function nonNullable<T>(value: T): value is NonNullable<T> {
   return value != null;

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,11 +1,15 @@
-import React, { useMemo } from "react";
-import { iso } from "@iso";
+import React, { useMemo } from 'react';
+
+import { iso } from '@iso';
 
 function nonNullable<T>(value: T): value is NonNullable<T> {
   return value != null;
 }
 
-function toSorted<T>(arr: T[], comparator: (a: T, b: T) => number): T[] {
+function toSorted<T>(
+  arr: readonly T[],
+  comparator: (a: T, b: T) => number
+): T[] {
   const sorted = [...arr];
   sorted.sort(comparator);
   return sorted;

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-
 import { iso } from '@iso';
 
 function nonNullable<T>(value: T): value is NonNullable<T> {


### PR DESCRIPTION
add `readonly` to arr parameter